### PR TITLE
로그인폼 입력상태, 오류상태 스토리 추가

### DIFF
--- a/src/containers/LoginForm/LoginForm.js
+++ b/src/containers/LoginForm/LoginForm.js
@@ -10,7 +10,7 @@ import {
 } from './LoginForm.module.scss';
 import { ReactComponent as ArrowIcon } from 'assets/arrow.svg';
 import classNames from 'classnames';
-import { string, number, object, oneOfType } from 'prop-types';
+import { string, number, object, oneOfType, bool } from 'prop-types';
 import { isValidEmailFormat, isValidPasswordFormat } from 'utils';
 import {
   IconInput,
@@ -20,13 +20,13 @@ import {
   A11yHidden,
 } from 'components';
 
-const LoginForm = ({ width, className, style }) => {
-  const [userId, setUserId] = useState(null);
-  const [userPw, setUserPw] = useState(null);
+const LoginForm = ({ width, className, style, id, password, autoLogin }) => {
+  const [userId, setUserId] = useState(id);
+  const [userPw, setUserPw] = useState(password);
   const [errorMessageId, setErrorMessageId] = useState(null);
   const [errorMessagePw, setErrorMessagePw] = useState(null);
-  const [isFormValidate, setIsFormValidate] = useState(true);
-  const [isCheckedAutoLogin, setIsCheckedAutoLogin] = useState(false);
+  const [isFormValidate, setIsFormValidate] = useState(false);
+  const [isCheckedAutoLogin, setIsCheckedAutoLogin] = useState(autoLogin);
 
   const handleUpdateCheckState = () => {
     setIsCheckedAutoLogin(!isCheckedAutoLogin);
@@ -42,7 +42,7 @@ const LoginForm = ({ width, className, style }) => {
 
   useEffect(() => {
     setErrorMessageId(
-      userId === null || isValidEmailFormat(userId)
+      userId === undefined || isValidEmailFormat(userId)
         ? null
         : userId === ''
         ? '아이디(이메일)를 입력해주세요.'
@@ -52,7 +52,7 @@ const LoginForm = ({ width, className, style }) => {
 
   useEffect(() => {
     setErrorMessagePw(
-      userPw === null || isValidPasswordFormat(userPw)
+      userPw === undefined || isValidPasswordFormat(userPw)
         ? null
         : userPw === ''
         ? '비밀번호를 입력해주세요.'
@@ -62,7 +62,7 @@ const LoginForm = ({ width, className, style }) => {
 
   useEffect(() => {
     setIsFormValidate(
-      isValidEmailFormat(userId) && isValidPasswordFormat(userPw) ? false : true
+      isValidEmailFormat(userId) && isValidPasswordFormat(userPw)
     );
   }, [userId, userPw]);
 
@@ -103,7 +103,7 @@ const LoginForm = ({ width, className, style }) => {
           </a>
         </div>
         <div className={buttonGroup}>
-          <Button className={button} disabled={isFormValidate}>
+          <Button className={button} disabled={!isFormValidate}>
             로그인
           </Button>
           <Divider />
@@ -123,6 +123,9 @@ LoginForm.propTypes = {
   className: string,
   /** 사용자 정의 스타일 객체를 설정할 수 있습니다. */
   style: object,
+  id: string,
+  password: string,
+  autoLogin: bool,
 };
 
 export default LoginForm;

--- a/src/containers/LoginForm/LoginForm.module.scss
+++ b/src/containers/LoginForm/LoginForm.module.scss
@@ -1,6 +1,7 @@
 .form {
   display: inline-flex;
   flex-flow: column;
+  text-align: left;
 }
 
 .control {

--- a/src/containers/LoginForm/LoginFrom.stories.js
+++ b/src/containers/LoginForm/LoginFrom.stories.js
@@ -1,65 +1,90 @@
-import LoginForm from "./LoginForm";
+import LoginForm from './LoginForm';
 
 export default {
   title: 'Containers/Form/LoginForm',
   component: LoginForm,
+  decorators: [
+    (Story) => (
+      <div style={{ marginTop: '20px', textAlign: 'center' }}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
+    width: {
+      control: { type: 'range', min: 400, max: 800 },
+    },
     className: {
-      control: false
+      control: false,
     },
     style: {
-      control: false
-    }
+      control: false,
+    },
+    id: {
+      table: {
+        disable: true,
+      },
+    },
+    password: {
+      table: {
+        disable: true,
+      },
+    },
+    autoLogin: {
+      table: {
+        disable: true,
+      },
+    },
   },
-  args : {
-    width: 576
+  args: {
+    width: 576,
   },
   parameters: {
     design: {
       type: 'figma',
       url:
         'https://www.figma.com/file/QNttUlYVQ1wMHo2E2ndD7J/SignIn-%E2%86%90-Coupang?node-id=886%3A37',
-    }
-  }
-}
+    },
+  },
+};
 
-const template = args => <LoginForm {...args}/>
+const template = (args) => <LoginForm {...args} />;
 
-export const mobileLoginForm = template.bind({}); 
+export const mobileLoginForm = template.bind({});
 mobileLoginForm.storyName = '로그인 폼 (모바일)';
-mobileLoginForm.argTypes = {
-  width: { 
-    control: { type: 'range', min: 320, max: 800 }
-  }
-}
 mobileLoginForm.args = {
-  width: 320
-}
+  width: 320,
+};
 
-export const defaultLoginForm = template.bind({}); 
+export const defaultLoginForm = template.bind({});
 defaultLoginForm.storyName = '로그인 폼 (초기 상태)';
-defaultLoginForm.argTypes = {
-  width: { 
-    control: { type: 'range', min: 400, max: 800 }
-  }
-}
 
-export const errorLoginForm = template.bind({}); 
+export const errorLoginForm = template.bind({});
 errorLoginForm.storyName = '로그인 폼 (입력 상태)';
+errorLoginForm.args = {
+  id: 'dkwkdnwk@naver.com',
+  password: 'abc123',
+  autoLogin: true,
+};
 errorLoginForm.parameters = {
   design: {
     type: 'figma',
     url:
       'https://www.figma.com/file/QNttUlYVQ1wMHo2E2ndD7J/SignIn-%E2%86%90-Coupang?node-id=886%3A435',
-  }
-}
+  },
+};
 
-export const typingLoginForm = template.bind({}); 
+export const typingLoginForm = template.bind({});
 typingLoginForm.storyName = '로그인 폼 (오류 상태)';
+typingLoginForm.args = {
+  id: 'dkwkdnwk@',
+  password: 'abc',
+  autoLogin: true,
+};
 typingLoginForm.parameters = {
   design: {
     type: 'figma',
     url:
       'https://www.figma.com/file/QNttUlYVQ1wMHo2E2ndD7J/SignIn-%E2%86%90-Coupang?node-id=886%3A336',
-  }
-}
+  },
+};


### PR DESCRIPTION
- id, pw, autoLogin props 추가
  - 상태값은 스토리 테스트 불가, props로 다 넘겨주는게 맞는가..?
- width range 공통 argTypes control로 적용
- isFormValidate 변수명에 맞게 값 수정
- decorator 추가
  - 데코레이터는 story를 렌더링할때 임의의 마크업으로 컴포넌트를 래핑하는 메커니즘
  - 컴포넌트의 Story에 스타일 래퍼를 추가하기 위해 데코레이터 사용(로그인폼을 뷰포트의 가운데로 적용)
  - Story를 감싸는 데코레이터를 작성하면 Storybook 뷰포트에 스타일이 반영된 래퍼 요소가 렌더링됨
  - text-align: center를 사용해서 form 컴포넌트 style에 text-align: left를 따로 적용했는데,, 기존 파일 수정 없는 방법 고민 필요 (margin: 0 auto 는 width값 지정 해야 돼서 못함)